### PR TITLE
Make use of StringBuilder

### DIFF
--- a/OpenDataInfrabel/OpenDataInfrabel/OpenDataCall.cs
+++ b/OpenDataInfrabel/OpenDataInfrabel/OpenDataCall.cs
@@ -1,34 +1,45 @@
-﻿using System;
+using System;
+using System.Text;
 using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace OpenDataInfrabel
 {
-    public class OpenDataCall:IDisposable
+    public class OpenDataCall : IDisposable
     {
+        private static readonly string url = "https://opendata.infrabel.be/api/records/1.0/search/?";
         private readonly HttpClient httpClient;
         private bool disposed = false;
-        private static readonly string url = "https://opendata.infrabel.be/api/records/1.0/search/?";
-        public OpenDataCall() => httpClient = new HttpClient();
+        
+        public OpenDataCall()
+        {
+            httpClient = new HttpClient();
+        }
+        
         protected async Task<string> MakeCall(string dataset, string q, string lang, int rows, int start, string[] facet)
         {
-            var finalUrl = url + "dataset=" + dataset;
+            StringBuilder finalUrl = new StringBuilder($"{url}dataset={dataset}");
             for (int i = 0; i < facet.Length; i++)
             {
-                finalUrl += ("&facet=" + facet[i]);
+                finalUrl.Append($"&facet={facet[i]}");
             }
-            finalUrl += (q == null ? "" : "&q=" + q) + "&lang=" + lang + "&rows=" + rows + "&start=" + start;
-            var request = await httpClient.GetAsync(finalUrl);
+            finalUrl.Append(q == null ? "" : $"&q={q}"));
+            finalUrl.Append($"&lang={lang}&rows={rows}&start={start}");
+
+            var request = await httpClient.GetAsync(finalUrl.ToString());
             if (request.StatusCode != System.Net.HttpStatusCode.OK)
                 return null;
+
             var requestString = await request.Content.ReadAsStringAsync();
             return requestString;
         }
+        
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
+        
         protected virtual void Dispose(bool disposing)
         {
             if (!disposed)

--- a/OpenDataInfrabel/OpenDataInfrabel/OpenDataCall.cs
+++ b/OpenDataInfrabel/OpenDataInfrabel/OpenDataCall.cs
@@ -18,7 +18,7 @@ namespace OpenDataInfrabel
         
         protected async Task<string> MakeCall(string dataset, string q, string lang, int rows, int start, string[] facet)
         {
-            StringBuilder finalUrl = new StringBuilder($"{url}dataset={dataset}");
+            var finalUrl = new StringBuilder($"{url}dataset={dataset}");
             for (int i = 0; i < facet.Length; i++)
             {
                 finalUrl.Append($"&facet={facet[i]}");

--- a/README.MD
+++ b/README.MD
@@ -1,31 +1,31 @@
 
 # How to use it?
-You just need to put this inside you Nuget Package:
+You just need to reference it in your project using this command line :
 ```
 Install-Package OpenDataInfrabel -Version 0.3.0
 ```
 # How to get data from API?
-### For infrastructure theme
+### Infrastructure Theme
 ```
 IInfrastructure infrastructure = new Infrastructure();
 var result = await infrastructure.GetKilometersMarkersNetwork();
 ```
-### For security theme
+### Security Theme
 ```
 ISecurity security = new Security();
 var result = await security.GetAccidentsCSI();
 ```
-### For traffic Management theme
+### Traffic Management Theme
 ```
 ITrafficManagement trafficManagement = new TrafficManagement();
 var result = await trafficManagement.GetMobipulseData();
 ```
-### For human ressources theme
+### Human Ressources Theme
 ```
 IHumanRessources humanRessources = new HumanRessources();
 var result = await humanRessources.GetDistributionStaffByGender();
 ```
-### For Client products theme
+### Client Products Theme
 ```
 IClientsProducts clientsProducts = new ClientsProducts();
 var result = await clientsProducts.GetEvolutionNetTonnageYear();


### PR DESCRIPTION
Use StringBuilder with string interpolation instead of string concatenation will result in higher performances when dealing with long string arrays and loops you don't know the size of (meaning that they could be very long or very short).

I highly suggest reading these articles :
- [The Sad Tragedy of Micro-Optimization](https://blog.codinghorror.com/the-sad-tragedy-of-micro-optimization-theater/)
- [StringBuilder and String Concatenation](https://www.c-sharpcorner.com/article/stringbuilder-and-string-concatenation/)
- [The Difference between String and StringBuilder in CSharp](https://codingsonata.com/the-difference-between-string-and-stringbuilder-in-csharp/)